### PR TITLE
Use popsicle request library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client-oauth2",
   "version": "0.0.4",
-  "description": "A no-dependency library for executing OAuth 2.0 flows.",
+  "description": "Straight-forward library for executing OAuth 2.0 flows and making API requests.",
   "main": "client-oauth2.js",
   "scripts": {
     "test": "gulp lint && gulp test"
@@ -23,9 +23,10 @@
   "homepage": "https://github.com/mulesoft/js-client-oauth2",
   "devDependencies": {
     "chai": "^1.9.1",
+    "es6-promise": "^2.0.0",
     "gulp": "^3.8.6",
     "gulp-jshint": "^1.8.4",
-    "gulp-mocha": "^1.1.0",
+    "gulp-mocha": "^2.0.0",
     "is-travis": "^1.0.0",
     "karma": "^0.12.23",
     "karma-chrome-launcher": "^0.1.4",
@@ -34,8 +35,11 @@
     "karma-mocha": "^0.1.9",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon-chai": "^0.2.0",
-    "mocha": "^1.21.3",
-    "nock": "^0.46.0",
+    "mocha": "^2.0.1",
+    "nock": "^0.51.0",
     "require-dir": "^0.1.0"
+  },
+  "dependencies": {
+    "popsicle": "0.0.2"
   }
 }

--- a/tasks/support/karma.conf.js
+++ b/tasks/support/karma.conf.js
@@ -37,6 +37,9 @@ module.exports = function (config) {
      * @type {Array}
      */
     files: [
+      'node_modules/es6-promise/dist/es6-promise.js',
+      'test/support/globals.js',
+      'node_modules/popsicle/popsicle.js',
       'client-oauth2.js',
       'test/browser/**/*.js'
     ],

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -14,7 +14,10 @@ gulp.task('test:browser', function (done) {
 });
 
 gulp.task('test:node', function () {
-  return gulp.src('test/node/**/*.js', { read: false })
+  return gulp.src([
+    'test/support/globals.js',
+    'test/node/**/*.js'
+  ], { read: false })
     .pipe(mocha({ reporter: 'spec' }));
 });
 

--- a/test/browser/code.js
+++ b/test/browser/code.js
@@ -12,10 +12,9 @@ describe('code', function () {
   describe('#getUri', function () {
     it('should return a valid uri', function () {
       expect(githubAuth.code.getUri()).to.equal(
-        'https://github.com/login/oauth/authorize?scope=notifications&' +
-        'client_id=abc&' +
+        'https://github.com/login/oauth/authorize?client_id=abc&' +
         'redirect_uri=http%3A%2F%2Fexample.com%2Fauth%2Fcallback&' +
-        'response_type=code'
+        'scope=notifications&response_type=code'
       );
     });
   });
@@ -47,17 +46,16 @@ describe('code', function () {
       server.restore();
     });
 
-    it('should request the token', function (done) {
+    it('should request the token', function () {
       var uri = 'http://example.com/auth/callback?code=fbe55d970377e0686746&' +
         'state=7076840850058943';
 
-      githubAuth.code.getToken(uri, function (err, user) {
-        expect(user).to.an.instanceOf(ClientOAuth2.Token);
-        expect(user.accessToken).to.equal(accessToken);
-        expect(user.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+      return githubAuth.code.getToken(uri)
+        .then(function (user) {
+          expect(user).to.an.instanceOf(ClientOAuth2.Token);
+          expect(user.accessToken).to.equal(accessToken);
+          expect(user.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/browser/credentials.js
+++ b/test/browser/credentials.js
@@ -44,14 +44,13 @@ describe('credentials', function () {
       server.restore();
     });
 
-    it('should request the token', function (done) {
-      githubAuth.credentials.getToken(function (err, user) {
-        expect(user).to.an.instanceOf(ClientOAuth2.Token);
-        expect(user.accessToken).to.equal(accessToken);
-        expect(user.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+    it('should request the token', function () {
+      return githubAuth.credentials.getToken()
+        .then(function (user) {
+          expect(user).to.an.instanceOf(ClientOAuth2.Token);
+          expect(user.accessToken).to.equal(accessToken);
+          expect(user.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/browser/owner.js
+++ b/test/browser/owner.js
@@ -23,7 +23,7 @@ describe('owner', function () {
         'https://github.com/login/oauth/access_token',
         function (xhr) {
           expect(xhr.requestBody).to.equal(
-            'username=blakeembrey&password=hunter2&grant_type=password'
+            'scope=&username=blakeembrey&password=hunter2&grant_type=password'
           );
           expect(xhr.requestHeaders.Authorization).to.equal(authHeader);
 
@@ -43,14 +43,13 @@ describe('owner', function () {
       server.restore();
     });
 
-    it('should get the token on behalf of the user', function (done) {
-      githubAuth.owner.getToken('blakeembrey', 'hunter2', function (err, user) {
-        expect(user).to.an.instanceOf(ClientOAuth2.Token);
-        expect(user.accessToken).to.equal(accessToken);
-        expect(user.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+    it('should get the token on behalf of the user', function () {
+      return githubAuth.owner.getToken('blakeembrey', 'hunter2')
+        .then(function (user) {
+          expect(user).to.an.instanceOf(ClientOAuth2.Token);
+          expect(user.accessToken).to.equal(accessToken);
+          expect(user.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/browser/token.js
+++ b/test/browser/token.js
@@ -12,27 +12,28 @@ describe('token', function () {
   describe('#getUri', function () {
     it('should return a valid uri', function () {
       expect(githubAuth.token.getUri()).to.equal(
-        'https://github.com/login/oauth/authorize?scope=notifications&' +
-        'client_id=abc&' +
+        'https://github.com/login/oauth/authorize?client_id=abc&' +
         'redirect_uri=http%3A%2F%2Fexample.com%2Fauth%2Fcallback&' +
-        'response_type=token'
+        'scope=notifications&response_type=token'
       );
     });
   });
 
   describe('#getToken', function () {
     var accessToken = '4430eb16f4f6577c0f3a15fb6127cbf828a8e403';
+    var refreshToken = '4430eb16f4f6577c0f3a15fb6127cbf828a8e404';
 
-    it('should parse the token from the response', function (done) {
-      var uri = 'http://example.com/auth/callback#access_token=' + accessToken;
+    it('should parse the token from the response', function () {
+      var uri = 'http://example.com/auth/callback?' +
+        'refresh_token=' + refreshToken + '#access_token=' + accessToken;
 
-      githubAuth.token.getToken(uri, function (err, user) {
-        expect(user).to.an.instanceOf(ClientOAuth2.Token);
-        expect(user.accessToken).to.equal(accessToken);
-        expect(user.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+      return githubAuth.token.getToken(uri)
+        .then(function (user) {
+          expect(user).to.an.instanceOf(ClientOAuth2.Token);
+          expect(user.accessToken).to.equal(accessToken);
+          expect(user.refreshToken).to.equal(refreshToken);
+          expect(user.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/browser/user.js
+++ b/test/browser/user.js
@@ -1,4 +1,4 @@
-describe('user token instance', function () {
+describe('user', function () {
   var githubAuth = new ClientOAuth2({
     clientId:            'abc',
     clientSecret:        '123',
@@ -53,20 +53,19 @@ describe('user token instance', function () {
       server.restore();
     });
 
-    it('should make a request on behalf of the user', function (done) {
+    it('should make a request on behalf of the user', function () {
       return token.request({
         method: 'GET',
-        uri: 'http://api.github.com/user'
-      }, function (err, response) {
-        expect(response.raw).to.exist;
-        expect(response.status).to.equal(200);
-        expect(response.body).to.equal('{"username":"blakeembrey"}');
-        expect(response.headers).to.deep.equal({
-          'content-type': 'application/json'
+        url: 'http://api.github.com/user'
+      })
+        .then(function (res) {
+          expect(res.raw).to.exist;
+          expect(res.status).to.equal(200);
+          expect(res.body).to.deep.equal({ username: 'blakeembrey' });
+          expect(res.headers).to.deep.equal({
+            'content-type': 'application/json'
+          });
         });
-
-        return done(err);
-      });
     });
   });
 
@@ -103,14 +102,13 @@ describe('user token instance', function () {
       server.restore();
     });
 
-    it('should make a request to get a new access token', function (done) {
-      return currentToken.refresh(function (err, token) {
-        expect(token).to.an.instanceOf(ClientOAuth2.Token);
-        expect(token.accessToken).to.equal('def456token');
-        expect(token.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+    it('should make a request to get a new access token', function () {
+      return currentToken.refresh()
+        .then(function (token) {
+          expect(token).to.an.instanceOf(ClientOAuth2.Token);
+          expect(token.accessToken).to.equal('def456token');
+          expect(token.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/node/code.js
+++ b/test/node/code.js
@@ -16,10 +16,9 @@ describe('code', function () {
   describe('#getUri', function () {
     it('should return a valid uri', function () {
       expect(githubAuth.code.getUri()).to.equal(
-        'https://github.com/login/oauth/authorize?scope=notifications&' +
-        'client_id=abc&' +
+        'https://github.com/login/oauth/authorize?client_id=abc&' +
         'redirect_uri=http%3A%2F%2Fexample.com%2Fauth%2Fcallback&' +
-        'response_type=code'
+        'scope=notifications&response_type=code'
       );
     });
   });
@@ -37,17 +36,16 @@ describe('code', function () {
         });
     });
 
-    it('should request the token', function (done) {
+    it('should request the token', function () {
       var uri = 'http://example.com/auth/callback?code=fbe55d970377e0686746&' +
         'state=7076840850058943';
 
-      githubAuth.code.getToken(uri, function (err, user) {
-        expect(user).to.an.instanceOf(ClientOAuth2.Token);
-        expect(user.accessToken).to.equal(accessToken);
-        expect(user.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+      return githubAuth.code.getToken(uri)
+        .then(function (user) {
+          expect(user).to.an.instanceOf(ClientOAuth2.Token);
+          expect(user.accessToken).to.equal(accessToken);
+          expect(user.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/node/credentials.js
+++ b/test/node/credentials.js
@@ -34,14 +34,13 @@ describe('credentials', function () {
         });
     });
 
-    it('should request the token', function (done) {
-      githubAuth.credentials.getToken(function (err, user) {
-        expect(user).to.an.instanceOf(ClientOAuth2.Token);
-        expect(user.accessToken).to.equal(accessToken);
-        expect(user.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+    it('should request the token', function () {
+      return githubAuth.credentials.getToken()
+        .then(function (user) {
+          expect(user).to.an.instanceOf(ClientOAuth2.Token);
+          expect(user.accessToken).to.equal(accessToken);
+          expect(user.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/node/owner.js
+++ b/test/node/owner.js
@@ -24,7 +24,7 @@ describe('owner', function () {
       })
         .post(
           '/login/oauth/access_token',
-          'username=blakeembrey&password=hunter2&grant_type=password'
+          'scope=&username=blakeembrey&password=hunter2&grant_type=password'
         )
         .reply(200, {
           access_token: accessToken,
@@ -33,14 +33,13 @@ describe('owner', function () {
         });
     });
 
-    it('should get the token on behalf of the user', function (done) {
-      githubAuth.owner.getToken('blakeembrey', 'hunter2', function (err, user) {
-        expect(user).to.an.instanceOf(ClientOAuth2.Token);
-        expect(user.accessToken).to.equal(accessToken);
-        expect(user.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+    it('should get the token on behalf of the user', function () {
+      return githubAuth.owner.getToken('blakeembrey', 'hunter2')
+        .then(function (user) {
+          expect(user).to.an.instanceOf(ClientOAuth2.Token);
+          expect(user.accessToken).to.equal(accessToken);
+          expect(user.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/node/token.js
+++ b/test/node/token.js
@@ -15,27 +15,28 @@ describe('token', function () {
   describe('#getUri', function () {
     it('should return a valid uri', function () {
       expect(githubAuth.token.getUri()).to.equal(
-        'https://github.com/login/oauth/authorize?scope=notifications&' +
-        'client_id=abc&' +
+        'https://github.com/login/oauth/authorize?client_id=abc&' +
         'redirect_uri=http%3A%2F%2Fexample.com%2Fauth%2Fcallback&' +
-        'response_type=token'
+        'scope=notifications&response_type=token'
       );
     });
   });
 
   describe('#getToken', function () {
     var accessToken = '4430eb16f4f6577c0f3a15fb6127cbf828a8e403';
+    var refreshToken = '4430eb16f4f6577c0f3a15fb6127cbf828a8e404';
 
-    it('should parse the token from the response', function (done) {
-      var uri = 'http://example.com/auth/callback#access_token=' + accessToken;
+    it('should parse the token from the response', function () {
+      var uri = 'http://example.com/auth/callback?' +
+        'refresh_token=' + refreshToken + '#access_token=' + accessToken;
 
-      githubAuth.token.getToken(uri, function (err, user) {
-        expect(user).to.an.instanceOf(ClientOAuth2.Token);
-        expect(user.accessToken).to.equal(accessToken);
-        expect(user.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+      return githubAuth.token.getToken(uri)
+        .then(function (user) {
+          expect(user).to.an.instanceOf(ClientOAuth2.Token);
+          expect(user.accessToken).to.equal(accessToken);
+          expect(user.refreshToken).to.equal(refreshToken);
+          expect(user.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/node/user.js
+++ b/test/node/user.js
@@ -2,7 +2,7 @@ var nock         = require('nock');
 var expect       = require('chai').expect;
 var ClientOAuth2 = require('../..');
 
-describe('user token instance', function () {
+describe('user', function () {
   var githubAuth = new ClientOAuth2({
     clientId:            'abc',
     clientSecret:        '123',
@@ -43,20 +43,19 @@ describe('user token instance', function () {
         });
     });
 
-    it('should make a request on behalf of the user', function (done) {
+    it('should make a request on behalf of the user', function () {
       return token.request({
         method: 'GET',
-        uri: 'http://api.github.com/user'
-      }, function (err, response) {
-        expect(response.raw).to.exist;
-        expect(response.status).to.equal(200);
-        expect(response.body).to.equal('{"username":"blakeembrey"}');
-        expect(response.headers).to.deep.equal({
-          'content-type': 'application/json'
+        url: 'http://api.github.com/user'
+      })
+        .then(function (res) {
+          expect(res.raw).to.exist;
+          expect(res.status).to.equal(200);
+          expect(res.body).to.deep.equal({ username: 'blakeembrey' });
+          expect(res.headers).to.deep.equal({
+            'content-type': 'application/json'
+          });
         });
-
-        return done(err);
-      });
     });
   });
 
@@ -79,14 +78,13 @@ describe('user token instance', function () {
         });
     });
 
-    it('should make a request to get a new access token', function (done) {
-      return currentToken.refresh(function (err, token) {
-        expect(token).to.an.instanceOf(ClientOAuth2.Token);
-        expect(token.accessToken).to.equal('def456token');
-        expect(token.tokenType).to.equal('bearer');
-
-        return done(err);
-      });
+    it('should make a request to get a new access token', function () {
+      return currentToken.refresh()
+        .then(function (token) {
+          expect(token).to.an.instanceOf(ClientOAuth2.Token);
+          expect(token.accessToken).to.equal('def456token');
+          expect(token.tokenType).to.equal('bearer');
+        });
     });
   });
 });

--- a/test/support/globals.js
+++ b/test/support/globals.js
@@ -1,0 +1,5 @@
+if (typeof window === 'object') {
+  window.ES6Promise.polyfill();
+} else {
+  require('es6-promise').polyfill();
+}


### PR DESCRIPTION
Updated to use the cross-platform interface of popsicle and support promises instead of callbacks.
