### PR TITLE
A token is expired if its expiration date before the current one, not the reverse.

### DIFF
--- a/client-oauth2.js
+++ b/client-oauth2.js
@@ -470,7 +470,7 @@
    */
   ClientOAuth2Token.prototype.expired = function () {
     if (this.expires) {
-      return Date.now() < this.expires.getTime()
+      return Date.now() > this.expires.getTime()
     }
 
     return false

--- a/test/user.js
+++ b/test/user.js
@@ -100,4 +100,16 @@ describe('user', function () {
         })
     })
   })
+
+  describe('#expired', function () {
+    it('should return false when token is not expired', function () {
+      user.expiresIn(10)
+      expect(user.expired()).to.be.equal(false)
+    });
+
+    it('should return true when token is expired', function () {
+      user.expiresIn(-10)
+      expect(user.expired()).to.be.equal(true)
+    });
+  });
 })

--- a/test/user.js
+++ b/test/user.js
@@ -105,11 +105,11 @@ describe('user', function () {
     it('should return false when token is not expired', function () {
       user.expiresIn(10)
       expect(user.expired()).to.be.equal(false)
-    });
+    })
 
     it('should return true when token is expired', function () {
       user.expiresIn(-10)
       expect(user.expired()).to.be.equal(true)
-    });
-  });
+    })
+  })
 })


### PR DESCRIPTION
The test condition in ClientOAuth2#expired() is wrong and the result is the reverse of what one would expect.
