### PR TITLE
Include client_id, client_secret in password auth.

### DIFF
--- a/client-oauth2.js
+++ b/client-oauth2.js
@@ -509,6 +509,9 @@
   /**
    * Make a request on behalf of the user credentials to get an acces token.
    *
+   * Reference: http://tools.ietf.org/html/rfc6749#section-4.3.2
+   * Reference: https://tools.ietf.org/html/rfc6749#section-3.2.1
+   *
    * @param  {String}  username
    * @param  {String}  password
    * @return {Promise}
@@ -528,7 +531,9 @@
         scope: sanitizeScope(options.scopes),
         username: username,
         password: password,
-        grant_type: 'password'
+        grant_type: 'password',
+        client_id: options.clientId,
+        client_secret: options.clientSecret
       }
     })
       .then(handleAuthResponse)


### PR DESCRIPTION
The `client_id` and `client_secret` parameters are not always required for 'password' auth, but can be required for confidential client types.

[Section 4.3.2, Access Token Request](https://tools.ietf.org/html/rfc6749#section-4.3.2), on 'password' auth, states:
> If the client type is confidential or the client was issued client
> credentials (or assigned other authentication requirements), the
> client MUST authenticate with the authorization server as described
> in Section 3.2.1.

[Section 3.2.1 Client Authentication](https://tools.ietf.org/html/rfc6749#section-3.2.1), states:
> Confidential clients or other clients issued client credentials MUST
> authenticate with the authorization server as described in
> Section 2.3 when making requests to the token endpoint.
> […]
> A client MAY use the "client_id" request parameter to identify itself
> when sending requests to the token endpoint.