### PR TITLE
Replace `popsicle` with an inlined request handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![NPM downloads][downloads-image]][downloads-url]
 [![Build status][travis-image]][travis-url]
 
-> Straight-forward execution of OAuth 2.0 flows and authenticated API requests.
+> Straight-forward execution of OAuth 2.0 flows and authenticated API requests. 7.58 kB in browsers, after minification and gzipping, 75% from `url` and `querystring` dependencies.
 
 ## Installation
 
@@ -30,6 +30,8 @@ var githubAuth = new ClientOAuth2({
 })
 ```
 
+**P.S.** The second argument to the constructor can inject a custom request function, and the third argument can inject a custom `Promise` implementation.
+
 ### Options (global and method-based)
 
 * **clientId** The client id string assigned to you by the provider
@@ -45,6 +47,7 @@ var githubAuth = new ClientOAuth2({
 * **body** An object to merge with the body of every request
 * **query** An object to merge with the query parameters of every request
 * **headers** An object to merge with the headers of every request
+* **transport** Change certain request transport behaviour (currently `rejectUnauthorized` and `agent`)
 
 To re-create an access token instance and make requests on behalf on the user, you can create an access token instance by using the `createToken` method on a client instance.
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -32,6 +32,16 @@ module.exports = function (config) {
     },
 
     /**
+     * Transform browserify when bundling.
+     *
+     * @type {Object}
+     */
+    browserify: {
+      debug: true,
+      transform: ['envify']
+    },
+
+    /**
      * List of files and patterns to load in the browser.
      *
      * @type {Array}

--- a/package.json
+++ b/package.json
@@ -2,19 +2,22 @@
   "name": "client-oauth2",
   "version": "2.2.0",
   "description": "Straight-forward execution of OAuth 2.0 flows and authenticated API requests",
-  "main": "client-oauth2.js",
+  "main": "src/client-oauth2.js",
   "files": [
-    "client-oauth2.js",
+    "src/",
     "LICENSE"
   ],
   "browser": {
-    "buffer": false
+    "buffer": false,
+    "./src/request/index.js": "./src/request/browser.js"
   },
   "scripts": {
     "lint": "standard",
-    "test-browser": "karma start --single-run",
-    "test-node": "mocha -R spec --bail --require test/support/globals.js",
-    "test": "npm run lint && npm run test-node && npm run test-browser"
+    "test-server-open": "PORT=7357 node test/support/server.js & echo $! > server.pid",
+    "test-server-close": "if [ -f server.pid ]; then kill -9 $(cat server.pid); rm server.pid; fi",
+    "test-browser": "PORT=7357 karma start --single-run",
+    "test-node": "PORT=7357 mocha -R spec --bail --require test/support/globals.js",
+    "test": "npm run lint && npm run test-server-open && npm run test-node && npm run test-browser; npm run test-server-close"
   },
   "repository": {
     "type": "git",
@@ -32,9 +35,13 @@
   },
   "homepage": "https://github.com/mulesoft/js-client-oauth2",
   "devDependencies": {
+    "body-parser": "^1.15.2",
     "browserify": "^13.1.0",
     "chai": "^3.2.0",
+    "cors": "^2.8.1",
+    "envify": "^3.4.1",
     "es6-promise": "^3.1.2",
+    "express": "^4.14.0",
     "is-travis": "^1.0.0",
     "karma": "^1.3.0",
     "karma-browserify": "^5.0.2",
@@ -52,7 +59,6 @@
     "watchify": "^3.7.0"
   },
   "dependencies": {
-    "popsicle": "^8.2.0",
     "xtend": "^4.0.1"
   }
 }

--- a/src/request/browser.js
+++ b/src/request/browser.js
@@ -1,0 +1,34 @@
+/**
+ * Make a request using `XMLHttpRequest`.
+ *
+ * @param   {String}  method
+ * @param   {String}  url
+ * @param   {String}  body
+ * @param   {Object}  headers
+ * @param   {Promise} Promise
+ * @returns {Promise}
+ */
+module.exports = function request (method, url, body, headers, Promise) {
+  return new Promise(function (resolve, reject) {
+    var xhr = new window.XMLHttpRequest()
+
+    xhr.open(method, url)
+
+    xhr.onload = function () {
+      return resolve({
+        status: xhr.status,
+        body: xhr.responseText
+      })
+    }
+
+    xhr.onerror = xhr.onabort = function () {
+      return reject(new Error(xhr.statusText || 'XHR aborted: ' + url))
+    }
+
+    Object.keys(headers).forEach(function (header) {
+      xhr.setRequestHeader(header, headers[header])
+    })
+
+    xhr.send(body)
+  })
+}

--- a/src/request/index.js
+++ b/src/request/index.js
@@ -1,0 +1,56 @@
+var http = require('http')
+var https = require('https')
+var Url = require('url')
+var createUnzip = require('zlib').createUnzip
+
+/**
+ * Make a request using node HTTP(s).
+ *
+ * @param   {String}  method
+ * @param   {String}  url
+ * @param   {String}  body
+ * @param   {Object}  headers
+ * @param   {Promise} Promise
+ * @returns {Promise}
+ */
+module.exports = function request (method, url, body, headers, Promise) {
+  return new Promise(function (resolve, reject) {
+    var requestOptions = Url.parse(url)
+    var lib = requestOptions.protocol === 'https:' ? https : http
+
+    requestOptions.method = method
+    requestOptions.headers = headers
+
+    // Send the http request and listen for the response to finish.
+    var request = lib.request(requestOptions, function (res) {
+      var data = ''
+      var stream = res
+      var encoding = res.headers['content-encoding']
+
+      if (encoding === 'deflate' || encoding === 'gzip') {
+        var unzip = createUnzip()
+        unzip.on('error', reject)
+        stream.pipe(unzip)
+        stream = unzip
+      }
+
+      stream.on('error', reject)
+
+      stream.on('data', function (chunk) {
+        data += chunk
+      })
+
+      stream.on('end', function () {
+        return resolve({
+          status: res.statusCode,
+          body: data
+        })
+      })
+    })
+
+    request.on('error', reject)
+
+    request.write(body)
+    request.end()
+  })
+}

--- a/test/jwtbearer.js
+++ b/test/jwtbearer.js
@@ -1,87 +1,50 @@
-/* global describe, it, btoa */
+/* global describe, it */
 var expect = require('chai').expect
+var config = require('./support/config')
 var ClientOAuth2 = require('../')
 
 describe('jwt', function () {
-  var accessTokenUri = 'https://github.com/login/oauth/access_token'
-
-  var token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2p3dC1pZHAuZXhhbXBsZS5jb20iLCJzdWIiOiJtYWlsdG86bWlrZUBleGFtcGxlLmNvbSIsImF1ZCI6Imh0dHBzOi8vand0LXJwLmV4YW1wbGUubmV0IiwibmJmIjoxMzAwODE1NzgwLCJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9jbGFpbXMuZXhhbXBsZS5jb20vbWVtYmVyIjp0cnVlLCJpYXQiOjE0MjQwMTE1ODN9.HWUPsjnh8UgCji9phLIQMTbJZySRV33kA-47Fn6NNqw'
-  var accessToken = '4430eb16f4f6577c0f3a15fb6127cbf828a8e403'
-  var refreshToken = accessToken.split('').reverse().join('')
-  var refreshAccessToken = 'def456token'
-
   var githubAuth = new ClientOAuth2({
-    clientId: 'abc',
-    clientSecret: '123',
-    accessTokenUri: accessTokenUri,
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    accessTokenUri: config.accessTokenUri,
     authorizationGrants: ['jwt'],
     scopes: ['notifications']
   })
 
-  githubAuth._request = function (req) {
-    if (req.method === 'POST' && req.url === accessTokenUri) {
-      var isRefreshToken = req.body.grant_type === 'refresh_token'
-
-      expect(req.headers.Authorization).to.equal('Basic ' + btoa('abc:123'))
-
-      if (isRefreshToken) {
-        expect(req.body.refresh_token).to.equal(refreshToken)
-      } else {
-        expect(req.body.scope).to.equal('notifications')
-        expect(req.body.grant_type).to.equal('urn:ietf:params:oauth:grant-type:jwt-bearer')
-        expect(req.body.assertion).to.equal(token)
-      }
-
-      return Promise.resolve({
-        status: 200,
-        body: {
-          access_token: isRefreshToken ? refreshAccessToken : accessToken,
-          refresh_token: refreshToken,
-          token_type: 'bearer',
-          scope: 'notifications'
-        },
-        headers: {
-          'content-type': 'application/json'
-        }
-      })
-    }
-
-    return Promise.reject(new TypeError('Not here'))
-  }
-
   describe('#getToken', function () {
     it('should request the token', function () {
-      return githubAuth.jwt.getToken(token)
+      return githubAuth.jwt.getToken(config.jwt)
         .then(function (user) {
           expect(user).to.an.instanceOf(ClientOAuth2.Token)
-          expect(user.accessToken).to.equal(accessToken)
+          expect(user.accessToken).to.equal(config.accessToken)
           expect(user.tokenType).to.equal('bearer')
         })
     })
 
     describe('#sign', function () {
       it('should be able to sign a standard request object', function () {
-        return githubAuth.jwt.getToken(token)
+        return githubAuth.jwt.getToken(config.jwt)
           .then(function (token) {
             var obj = token.sign({
               method: 'GET',
               url: 'http://api.github.com/user'
             })
 
-            expect(obj.headers.Authorization).to.equal('Bearer ' + accessToken)
+            expect(obj.headers.Authorization).to.equal('Bearer ' + config.accessToken)
           })
       })
     })
 
     describe('#refresh', function () {
       it('should make a request to get a new access token', function () {
-        return githubAuth.jwt.getToken(token)
+        return githubAuth.jwt.getToken(config.jwt)
           .then(function (token) {
             return token.refresh()
           })
           .then(function (token) {
             expect(token).to.an.instanceOf(ClientOAuth2.Token)
-            expect(token.accessToken).to.equal('def456token')
+            expect(token.accessToken).to.equal(config.refreshAccessToken)
             expect(token.tokenType).to.equal('bearer')
           })
       })

--- a/test/owner.js
+++ b/test/owner.js
@@ -1,86 +1,50 @@
-/* global describe, it, btoa */
+/* global describe, it */
 var expect = require('chai').expect
+var config = require('./support/config')
 var ClientOAuth2 = require('../')
 
 describe('owner', function () {
-  var accessTokenUri = 'https://github.com/login/oauth/access_token'
-
-  var accessToken = '4430eb16f4f6577c0f3a15fb6127cbf828a8e403'
-  var refreshToken = accessToken.split('').reverse().join('')
-  var refreshAccessToken = 'def456token'
-
   var githubAuth = new ClientOAuth2({
-    clientId: 'abc',
-    clientSecret: '123',
-    accessTokenUri: accessTokenUri,
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    accessTokenUri: config.accessTokenUri,
     authorizationGrants: ['owner'],
     scope: 'notifications'
   })
 
-  githubAuth._request = function (req) {
-    if (req.method === 'POST' && req.url === accessTokenUri) {
-      var isRefreshToken = req.body.grant_type === 'refresh_token'
-
-      expect(req.headers.Authorization).to.equal('Basic ' + btoa('abc:123'))
-
-      if (isRefreshToken) {
-        expect(req.body.refresh_token).to.equal(refreshToken)
-      } else {
-        expect(req.body.grant_type).to.equal('password')
-        expect(req.body.username).to.equal('blakeembrey')
-        expect(req.body.password).to.equal('hunter2')
-      }
-
-      return Promise.resolve({
-        status: 200,
-        body: {
-          access_token: isRefreshToken ? refreshAccessToken : accessToken,
-          refresh_token: refreshToken,
-          token_type: 'bearer',
-          scope: 'notifications'
-        },
-        headers: {
-          'content-type': 'application/json'
-        }
-      })
-    }
-
-    return Promise.reject(new TypeError('Not here'))
-  }
-
   describe('#getToken', function () {
     it('should get the token on behalf of the user', function () {
-      return githubAuth.owner.getToken('blakeembrey', 'hunter2')
+      return githubAuth.owner.getToken(config.username, config.password)
         .then(function (user) {
           expect(user).to.an.instanceOf(ClientOAuth2.Token)
-          expect(user.accessToken).to.equal(accessToken)
+          expect(user.accessToken).to.equal(config.accessToken)
           expect(user.tokenType).to.equal('bearer')
         })
     })
 
     describe('#sign', function () {
       it('should be able to sign a standard request object', function () {
-        return githubAuth.owner.getToken('blakeembrey', 'hunter2')
+        return githubAuth.owner.getToken(config.username, config.password)
           .then(function (token) {
             var obj = token.sign({
               method: 'GET',
               url: 'http://api.github.com/user'
             })
 
-            expect(obj.headers.Authorization).to.equal('Bearer ' + accessToken)
+            expect(obj.headers.Authorization).to.equal('Bearer ' + config.accessToken)
           })
       })
     })
 
     describe('#refresh', function () {
       it('should make a request to get a new access token', function () {
-        return githubAuth.owner.getToken('blakeembrey', 'hunter2')
+        return githubAuth.owner.getToken(config.username, config.password)
           .then(function (token) {
             return token.refresh()
           })
           .then(function (token) {
             expect(token).to.an.instanceOf(ClientOAuth2.Token)
-            expect(token.accessToken).to.equal('def456token')
+            expect(token.accessToken).to.equal(config.refreshAccessToken)
             expect(token.tokenType).to.equal('bearer')
           })
       })

--- a/test/support/config.js
+++ b/test/support/config.js
@@ -1,0 +1,19 @@
+exports.accessTokenUri = 'http://localhost:' + process.env.PORT + '/login/oauth/access_token'
+exports.authorizationUri = 'http://localhost:' + process.env.PORT + '/login/oauth/authorize'
+
+exports.accessToken = '4430eb16f4f6577c0f3a15fb6127cbf828a8e403'
+exports.refreshToken = exports.accessToken.split('').reverse().join('')
+exports.refreshAccessToken = 'def456token'
+exports.refreshRefreshToken = exports.refreshAccessToken.split('').reverse().join('')
+exports.testRefreshAccessToken = 'testingtesting123'
+
+exports.clientId = 'abc'
+exports.clientSecret = '123'
+
+exports.code = 'fbe55d970377e0686746'
+exports.state = '7076840850058943'
+
+exports.jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2p3dC1pZHAuZXhhbXBsZS5jb20iLCJzdWIiOiJtYWlsdG86bWlrZUBleGFtcGxlLmNvbSIsImF1ZCI6Imh0dHBzOi8vand0LXJwLmV4YW1wbGUubmV0IiwibmJmIjoxMzAwODE1NzgwLCJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9jbGFpbXMuZXhhbXBsZS5jb20vbWVtYmVyIjp0cnVlLCJpYXQiOjE0MjQwMTE1ODN9.HWUPsjnh8UgCji9phLIQMTbJZySRV33kA-47Fn6NNqw'
+
+exports.username = 'blakeembrey'
+exports.password = 'hunter2'

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -1,0 +1,56 @@
+var express = require('express')
+var bodyParser = require('body-parser')
+var cors = require('cors')
+var assert = require('assert')
+var Querystring = require('querystring')
+var config = require('./config')
+var app = express()
+
+var credentials = 'Basic ' + new Buffer(config.clientId + ':' + config.clientSecret).toString('base64')
+
+app.options('/login/oauth/access_token', cors())
+
+app.post(
+  '/login/oauth/access_token',
+  cors(),
+  bodyParser.urlencoded({ extended: false }),
+  function (req, res) {
+    var grantType = req.body.grant_type
+
+    if (grantType === 'refresh_token') {
+      assert.equal(req.body.refresh_token, config.refreshToken)
+      assert.equal(req.headers.authorization, credentials)
+
+      return res.send(Querystring.stringify({
+        access_token: req.body.test ? config.testRefreshAccessToken : config.refreshAccessToken,
+        refresh_token: config.refreshRefreshToken,
+        expires_in: 3000
+      }))
+    }
+
+    if (grantType === 'authorization_code') {
+      assert.equal(req.body.client_id, config.clientId)
+      assert.equal(req.body.client_secret, config.clientSecret)
+      assert.equal(req.body.code, config.code)
+    } else if (grantType === 'urn:ietf:params:oauth:grant-type:jwt-bearer') {
+      assert.equal(req.body.assertion, config.jwt)
+      assert.equal(req.headers.authorization, credentials)
+    } else if (grantType === 'password') {
+      assert.equal(req.body.username, config.username)
+      assert.equal(req.body.password, config.password)
+      assert.equal(req.headers.authorization, credentials)
+    } else {
+      assert.equal(grantType, 'client_credentials')
+      assert.equal(req.headers.authorization, credentials)
+    }
+
+    return res.json({
+      access_token: config.accessToken,
+      refresh_token: config.refreshToken,
+      token_type: 'bearer',
+      scope: 'notifications'
+    })
+  }
+)
+
+app.listen(process.env.PORT || 7357)

--- a/test/token.js
+++ b/test/token.js
@@ -1,44 +1,23 @@
 /* global describe, it */
 var expect = require('chai').expect
+var config = require('./support/config')
 var ClientOAuth2 = require('../')
 
 describe('token', function () {
-  var authorizationUri = 'https://github.com/login/oauth/authorize'
-
-  var accessToken = '4430eb16f4f6577c0f3a15fb6127cbf828a8e403'
-  var uri = 'http://example.com/auth/callback' +
-    '#access_token=' + accessToken + '&token_type=bearer'
+  var uri = 'http://example.com/auth/callback#access_token=' + config.accessToken + '&token_type=bearer'
 
   var githubAuth = new ClientOAuth2({
-    clientId: 'abc',
-    authorizationUri: authorizationUri,
+    clientId: config.clientId,
+    authorizationUri: config.authorizationUri,
     authorizationGrants: ['token'],
     redirectUri: 'http://example.com/auth/callback',
     scopes: ['notifications']
   })
 
-  githubAuth._request = function (req) {
-    if (req.method === 'GET' && req.url === 'http://api.github.com/user') {
-      expect(req.headers.Authorization).to.equal('Bearer ' + accessToken)
-
-      return Promise.resolve({
-        status: 200,
-        body: {
-          username: 'blakeembrey'
-        },
-        headers: {
-          'content-type': 'application/json'
-        }
-      })
-    }
-
-    return Promise.reject(new TypeError('Not here'))
-  }
-
   describe('#getUri', function () {
     it('should return a valid uri', function () {
       expect(githubAuth.token.getUri()).to.equal(
-        'https://github.com/login/oauth/authorize?client_id=abc&' +
+        config.authorizationUri + '?client_id=abc&' +
         'redirect_uri=http%3A%2F%2Fexample.com%2Fauth%2Fcallback&' +
         'scope=notifications&response_type=token&state='
       )
@@ -50,7 +29,7 @@ describe('token', function () {
       return githubAuth.token.getToken(uri)
         .then(function (user) {
           expect(user).to.an.instanceOf(ClientOAuth2.Token)
-          expect(user.accessToken).to.equal(accessToken)
+          expect(user.accessToken).to.equal(config.accessToken)
           expect(user.tokenType).to.equal('bearer')
         })
     })
@@ -64,7 +43,7 @@ describe('token', function () {
               url: 'http://api.github.com/user'
             })
 
-            expect(obj.headers.Authorization).to.equal('Bearer ' + accessToken)
+            expect(obj.headers.Authorization).to.equal('Bearer ' + config.accessToken)
           })
       })
     })

--- a/test/user.js
+++ b/test/user.js
@@ -1,48 +1,21 @@
-/* global describe, it, btoa */
+/* global describe, it */
 var expect = require('chai').expect
+var config = require('./support/config')
 var ClientOAuth2 = require('../')
 
 describe('user', function () {
-  var accessTokenUri = 'https://github.com/login/oauth/access_token'
-  var authorizationUri = 'https://github.com/login/oauth/authorize'
-
-  var accessToken = '4430eb16f4f6577c0f3a15fb6127cbf828a8e403'
-  var refreshToken = accessToken.split('').reverse().join('')
-  var refreshAccessToken = 'def456token'
-  var refreshRefreshToken = refreshAccessToken.split('').reverse().join('')
-
   var githubAuth = new ClientOAuth2({
-    clientId: 'abc',
-    clientSecret: '123',
-    accessTokenUri: accessTokenUri,
-    authorizationUri: authorizationUri,
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+    accessTokenUri: config.accessTokenUri,
+    authorizationUri: config.authorizationUri,
     authorizationGrants: ['code'],
     redirectUri: 'http://example.com/auth/callback',
     scopes: 'notifications'
   })
 
-  githubAuth._request = function (req) {
-    if (req.method === 'POST' && req.url === accessTokenUri) {
-      expect(req.headers.Authorization).to.equal('Basic ' + btoa('abc:123'))
-      expect(req.body.grant_type).to.equal('refresh_token')
-      expect(req.body.refresh_token).to.equal(refreshToken)
-      expect(req.body.test).to.equal(true)
+  var user = githubAuth.createToken(config.accessToken, config.refreshToken, 'bearer')
 
-      return Promise.resolve({
-        status: 200,
-        body: {
-          access_token: refreshAccessToken,
-          refresh_token: refreshRefreshToken,
-          expires_in: 3000
-        },
-        headers: {
-          'content-type': 'application/json'
-        }
-      })
-    }
-  }
-
-  var user = githubAuth.createToken(accessToken, refreshToken, 'bearer')
   user.expiresIn(0)
 
   describe('#sign', function () {
@@ -55,21 +28,21 @@ describe('user', function () {
         }
       })
 
-      expect(obj.headers.Authorization).to.equal('Bearer ' + accessToken)
+      expect(obj.headers.Authorization).to.equal('Bearer ' + config.accessToken)
     })
   })
 
   describe('#refresh', function () {
     it('should make a request to get a new access token', function () {
-      expect(user.accessToken).to.equal(accessToken)
+      expect(user.accessToken).to.equal(config.accessToken)
       expect(user.tokenType).to.equal('bearer')
 
       return user.refresh({ body: { test: true } })
         .then(function (token) {
           expect(token).to.an.instanceOf(ClientOAuth2.Token)
-          expect(token.accessToken).to.equal(refreshAccessToken)
+          expect(token.accessToken).to.equal(config.testRefreshAccessToken)
           expect(token.tokenType).to.equal('bearer')
-          expect(token.refreshToken).to.equal(refreshRefreshToken)
+          expect(token.refreshToken).to.equal(config.refreshRefreshToken)
         })
     })
   })
@@ -77,11 +50,13 @@ describe('user', function () {
   describe('#expired', function () {
     it('should return false when token is not expired', function () {
       user.expiresIn(10)
+
       expect(user.expired()).to.be.equal(false)
     })
 
     it('should return true when token is expired', function () {
       user.expiresIn(-10)
+
       expect(user.expired()).to.be.equal(true)
     })
   })


### PR DESCRIPTION
Look at `request/{index.js,browser.js}`. Each are < 60 LOC, but provide everything this library would require. The only oddity here is redirect handling under node, so I might need to correct that.

Edit: Also need to add tests for the request handler, which means bringing in a server for tests.