### PR TITLE
Send `clientSecret` with header in code flow

### DIFF
--- a/test/support/server.js
+++ b/test/support/server.js
@@ -32,9 +32,8 @@ app.post(
     }
 
     if (grantType === 'authorization_code') {
-      assert.equal(req.body.client_id, config.clientId)
-      assert.equal(req.body.client_secret, config.clientSecret)
       assert.equal(req.body.code, config.code)
+      assert.equal(req.headers.authorization, credentials)
     } else if (grantType === 'urn:ietf:params:oauth:grant-type:jwt-bearer') {
       assert.equal(req.body.assertion, config.jwt)
       assert.equal(req.headers.authorization, credentials)


### PR DESCRIPTION
The `client_secret` is not required for "public clients", and the header is preferred anyway. I've also gone ahead and dropped the requirement for `redirect_uri` to be specified - according to the spec, it is not required.