### PR TITLE
fixes createToken(data) to accept data.expires_in in DateTime format

### DIFF
--- a/src/client-oauth2.js
+++ b/src/client-oauth2.js
@@ -297,7 +297,11 @@ function ClientOAuth2Token (client, data) {
   this.accessToken = data.access_token
   this.refreshToken = data.refresh_token
 
-  this.expiresIn(Number(data.expires_in))
+  if (typeof data.expires_in === 'string') {
+    if (isNaN(data.expires_in)) {
+      this.expiresIn(new Date(data.expires_in))
+    } else this.expiresIn(Number(data.expires_in))
+  } else this.expiresIn(data.expires_in)
 }
 
 /**


### PR DESCRIPTION
Issue https://github.com/mulesoft/js-client-oauth2/issues/106