### PR TITLE
bugfix authorization uri with existing query params not working

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ declare class ClientOAuth2 {
   owner: ClientOAuth2.OwnerFlow;
   credentials: ClientOAuth2.CredentialsFlow;
   jwt: ClientOAuth2.JwtBearerFlow;
+  options: ClientOAuth2.Options;
 
   constructor(options: ClientOAuth2.Options, request?: ClientOAuth2.Request);
 

--- a/src/client-oauth2.js
+++ b/src/client-oauth2.js
@@ -160,13 +160,14 @@ function createUri (options, tokenType) {
   // Check the required parameters are set.
   expects(options, 'clientId', 'authorizationUri')
 
-  return options.authorizationUri + '?' + Querystring.stringify(Object.assign({
+  var additionalQueryParams = Querystring.stringify(Object.assign({
     client_id: options.clientId,
     redirect_uri: options.redirectUri,
     scope: sanitizeScope(options.scopes),
     response_type: tokenType,
     state: options.state
   }, options.query))
+  return options.authorizationUri + (options.authorizationUri.indexOf('?') === -1 ? '?' : '&') + additionalQueryParams
 }
 
 /**

--- a/test/token.js
+++ b/test/token.js
@@ -22,6 +22,22 @@ describe('token', function () {
         'scope=notifications&response_type=token&state='
       )
     })
+
+    it('should handle authorization url with existing query param', function () {
+      var client = new ClientOAuth2({
+        clientId: config.clientId,
+        authorizationUri: config.authorizationUri + '?aParam=aValue',
+        authorizationGrants: ['token'],
+        redirectUri: config.redirectUri,
+        scopes: ['notifications']
+      })
+      expect(client.token.getUri()).to.equal(
+        config.authorizationUri + '?aParam=aValue&' +
+        'client_id=abc&' +
+        'redirect_uri=http%3A%2F%2Fexample.com%2Fauth%2Fcallback&' +
+        'scope=notifications&response_type=token&state='
+      )
+    })
   })
 
   describe('#getToken', function () {


### PR DESCRIPTION
Azure Active Directory B2C OpenID Connect requires custom query params in authorization urls. E.g. the param 'p=b2c_1_sign_up' in this example: https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-oidc#use-a-sign-up-user-flow.