### PR TITLE
Support Apple's OAuth

### DIFF
--- a/src/client-oauth2.js
+++ b/src/client-oauth2.js
@@ -165,7 +165,8 @@ function createUri (options, tokenType) {
     redirect_uri: options.redirectUri,
     scope: sanitizeScope(options.scopes),
     response_type: tokenType,
-    state: options.state
+    state: options.state,
+    response_mode: options.responseMode || "query"
   }, options.query))
 }
 
@@ -620,6 +621,8 @@ CodeFlow.prototype.getToken = function (uri, opts) {
   // Reference: https://tools.ietf.org/html/rfc6749#section-3.2.1
   if (options.clientSecret) {
     headers.Authorization = auth(options.clientId, options.clientSecret)
+    body.client_id = options.clientId
+    body.client_secret = options.clientSecret
   } else {
     body.client_id = options.clientId
   }


### PR DESCRIPTION
Apple's OAuth has some special requirements that necessitate changes in this library:

1. When any scopes are requested, the `response_mode` must be set to `form_post`. The service will then provide the `code` in a url-encoded form body.

The library only supports codes in the query string, but that be worked around easily, for example:

```
var url = req.originalUrl;
if (req.method == "POST")
	url += "?code=" + req.body.code;

provider.auth.code.getToken(url)
...
```

2. Apple seems to ignore the Authorization HTTP header when exchanging the code for a token. The authorization strings must go into the request body.