### PR TITLE
Copied getToken() conditions for clientSecret to refresh()

### DIFF
--- a/src/client-oauth2.js
+++ b/src/client-oauth2.js
@@ -367,16 +367,23 @@ ClientOAuth2Token.prototype.refresh = function (opts) {
     return Promise.reject(new Error('No refresh token'))
   }
 
+  var headers = Object.assign({}, DEFAULT_HEADERS)
+  var body = { refresh_token: this.refreshToken, grant_type: 'refresh_token' }
+
+  // `client_id`: REQUIRED, if the client is not authenticating with the
+  // authorization server as described in Section 3.2.1.
+  // Reference: https://tools.ietf.org/html/rfc6749#section-3.2.1
+  if (options.clientSecret) {
+    headers.Authorization = auth(options.clientId, options.clientSecret)
+  } else {
+    body.client_id = options.clientId
+  }
+
   return this.client._request(requestOptions({
     url: options.accessTokenUri,
     method: 'POST',
-    headers: Object.assign({}, DEFAULT_HEADERS, {
-      Authorization: auth(options.clientId, options.clientSecret)
-    }),
-    body: {
-      refresh_token: this.refreshToken,
-      grant_type: 'refresh_token'
-    }
+    headers: headers,
+    body: body
   }, options))
     .then(function (data) {
       return self.client.createToken(Object.assign({}, self.data, data))


### PR DESCRIPTION
Fix for #121

Adds a condition to refresh() to send the clientId to the body rather than using the auth() method in the Headers. Alternatively conditions could be set in the auth() method, but I figured we'd reuse the same logic.