### PR TITLE
fix invalid calling object 'btoa' in Edge (Chromium) #148

### DIFF
--- a/src/client-oauth2.js
+++ b/src/client-oauth2.js
@@ -8,7 +8,7 @@ var btoa
 if (typeof Buffer === 'function') {
   btoa = btoaBuffer
 } else {
-  btoa = window.btoa
+  btoa = window.btoa.bind(window)
 }
 
 /**


### PR DESCRIPTION
this will fix issues #148, #78  and also makes pr #70 obsolete.