### PR TITLE
Fixes #146: Rework handling state with an empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var githubAuth = new ClientOAuth2({
 * **authorizationUri** The url to redirect users to authenticate with the provider (only required for `token` and `code`)
 * **redirectUri** A custom url for the provider to redirect users back to your application (only required for `token` and `code`)
 * **scopes** An array of scopes to authenticate against
-* **state** Nonce sent back with the redirect when authorization is complete to verify authenticity (should be random for every request)
+* **state** Nonce sent back with the redirect when authorization is complete to verify authenticity (should be random for every request). Empty string is considered to be a missing state
 
 ### Request options
 

--- a/src/client-oauth2.js
+++ b/src/client-oauth2.js
@@ -497,7 +497,7 @@ TokenFlow.prototype.getToken = function (uri, opts) {
   }
 
   // Check whether the state matches.
-  if (options.state != null && data.state !== options.state) {
+  if (!!options.state && data.state !== options.state) {
     return Promise.reject(new TypeError('Invalid state: ' + data.state))
   }
 
@@ -606,7 +606,7 @@ CodeFlow.prototype.getToken = function (uri, opts) {
     return Promise.reject(err)
   }
 
-  if (options.state != null && data.state !== options.state) {
+  if (!!options.state && data.state !== options.state) {
     return Promise.reject(new TypeError('Invalid state: ' + data.state))
   }
 

--- a/test/code.js
+++ b/test/code.js
@@ -36,6 +36,25 @@ describe('code', function () {
         })
     })
 
+    it('should work with empty state', function () {
+      var githubAuthEmptyState = new ClientOAuth2({
+        clientId: config.clientId,
+        clientSecret: config.clientSecret,
+        accessTokenUri: config.accessTokenUri,
+        authorizationUri: config.authorizationUri,
+        authorizationGrants: ['code'],
+        redirectUri: config.redirectUri,
+        scopes: 'notifications',
+        state: ''
+      })
+      return githubAuthEmptyState.code.getToken(uri)
+        .then(function (user) {
+          expect(user).to.an.instanceOf(ClientOAuth2.Token)
+          expect(user.accessToken).to.equal(config.accessToken)
+          expect(user.tokenType).to.equal('bearer')
+        })
+    })
+
     it('should reject with auth errors', function () {
       var errored = false
 


### PR DESCRIPTION
Fixes #146 
Any falsy value is now considered a missing "state". This conforms the OAuth2.0 RFC, because the RFC says that the `state` value should be 1 or more chars (including whitespaces).

