### PR TITLE
Add a tsdoc comment about the units of number type parameter to expiresIn

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,6 +66,7 @@ declare namespace ClientOAuth2 {
     refreshToken: string;
 
     constructor(client: ClientOAuth2, data: Data);
+    /** A {number|Date} duration Seconds from now to expire, or a date to expire on. */
     expiresIn(duration: number | Date): Date;
     sign<T extends RequestObject>(requestObj: T): T;
     refresh(options?: Options): Promise<Token>;


### PR DESCRIPTION
The JSDoc comment has this comment already, but because I'm using typescript, the comment was not automatically shown (instead it uses the type definition and comments from there). I had a bug where I was passing milliseconds to `expiresIn` and this would have helped me catch it earlier or find the bug sooner.